### PR TITLE
prometheus operator support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "kube-prometheus"]
+	path = kube-prometheus
+	url = git@github.com:prometheus-operator/kube-prometheus.git

--- a/Makefile
+++ b/Makefile
@@ -230,3 +230,9 @@ catalog-build: opm
 .PHONY: catalog-push
 catalog-push: ## Push the catalog image.
 	$(MAKE) docker-push IMG=$(CATALOG_IMG)
+
+prometheus-operator: ## deploy operator for prometheus
+	kubectl create -f kube-prometheus/manifests/setup
+	sleep 30
+	kubectl create -f kube-prometheus/manifests/
+

--- a/api/v1beta1/ibporderer_types.go
+++ b/api/v1beta1/ibporderer_types.go
@@ -168,6 +168,14 @@ type IBPOrdererSpec struct {
 	// ExternalAddress (Optional) is used internally
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	ExternalAddress string `json:"externalAddress,omitempty"`
+
+	// PrometheusOperator(Optional) is used to integerate with prometheus operator for orderer deployment
+	// sample usage as prometheusoperator: true
+	// specify to enable prometheusoperator, we need configoverride.metrics.provider and configoverride.operations.listenAddress works
+	// CORE_METRICS_PROVIDER should be configured as prometheus by configoverride.metrics.provider
+	// meanwhile operator port should be configured as prometheus by configoverride.operations.listenAddress
+	// and a ServiceMonitor will be created for orderer
+	PrometheusOperator bool `json:"prometheusoperator,omitempty"`
 }
 
 // IBPOrdererClusterLocation (Optional) is object of cluster location settings for cluster

--- a/api/v1beta1/ibppeer_types.go
+++ b/api/v1beta1/ibppeer_types.go
@@ -151,6 +151,14 @@ type IBPPeerSpec struct {
 	// CHAINCODE_AS_A_SERVICE_BUILDER_CONFIG env variable.
 	// +operator-sdk:gen-csv:customresourcedefinitions.specDescriptors=true
 	ChaincodeBuilderConfig ChaincodeBuilderConfig `json:"chaincodeBuilderConfig,omitempty"`
+
+	// PrometheusOperator(Optional) is used to integerate with prometheus operator for peer deployment
+	// sample usage as prometheusoperator: true
+	// specify to enable prometheusoperator, we need configoverride.metrics.provider and configoverride.operations.listenAddress works
+	// CORE_METRICS_PROVIDER should be configured as prometheus by configoverride.metrics.provider
+	// meanwhile operator port should be configured as prometheus by configoverride.operations.listenAddress
+	// and a ServiceMonitor will be created for peer
+	PrometheusOperator bool `json:"prometheusoperator,omitempty"`
 }
 
 // +k8s:openapi-gen=true

--- a/config/crd/bases/ibp.com_ibpcas.yaml
+++ b/config/crd/bases/ibp.com_ibpcas.yaml
@@ -1,20 +1,3 @@
-#
-# Copyright contributors to the Hyperledger Fabric Operator project
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at:
-#
-# 	  http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/config/crd/bases/ibp.com_ibpconsoles.yaml
+++ b/config/crd/bases/ibp.com_ibpconsoles.yaml
@@ -1,20 +1,3 @@
-#
-# Copyright contributors to the Hyperledger Fabric Operator project
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at:
-#
-# 	  http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/config/crd/bases/ibp.com_ibporderers.yaml
+++ b/config/crd/bases/ibp.com_ibporderers.yaml
@@ -1,20 +1,3 @@
-#
-# Copyright contributors to the Hyperledger Fabric Operator project
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at:
-#
-# 	  http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -471,6 +454,15 @@ spec:
               orgName:
                 description: OrgName is the organization name of the orderer
                 type: string
+              prometheusoperator:
+                description: 'PrometheusOperator(Optional) is used to integerate with
+                  prometheus operator for orderer deployment sample usage as prometheusoperator:
+                  true specify to enable prometheusoperator, we need configoverride.metrics.provider
+                  and configoverride.operations.listenAddress works CORE_METRICS_PROVIDER
+                  should be configured as prometheus by configoverride.metrics.provider
+                  meanwhile operator port should be configured as prometheus by configoverride.operations.listenAddress
+                  and a ServiceMonitor will be created for orderer'
+                type: boolean
               region:
                 description: Region (Optional) is the region of the nodes where the
                   orderer should be deployed

--- a/config/crd/bases/ibp.com_ibppeers.yaml
+++ b/config/crd/bases/ibp.com_ibppeers.yaml
@@ -1,20 +1,3 @@
-#
-# Copyright contributors to the Hyperledger Fabric Operator project
-#
-# SPDX-License-Identifier: Apache-2.0
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at:
-#
-# 	  http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
@@ -287,6 +270,15 @@ spec:
                 description: PeerExternalEndpoint (Optional) is used to override peer
                   external endpoint
                 type: string
+              prometheusoperator:
+                description: 'PrometheusOperator(Optional) is used to integerate with
+                  prometheus operator for peer deployment sample usage as prometheusoperator:
+                  true specify to enable prometheusoperator, we need configoverride.metrics.provider
+                  and configoverride.operations.listenAddress works CORE_METRICS_PROVIDER
+                  should be configured as prometheus by configoverride.metrics.provider
+                  meanwhile operator port should be configured as prometheus by configoverride.operations.listenAddress
+                  and a ServiceMonitor will be created for peer'
+                type: boolean
               region:
                 description: Region (Optional) is the region of the nodes where the
                   peer should be deployed

--- a/config/samples/ibp.com_v1beta1_ibppeer.yaml
+++ b/config/samples/ibp.com_v1beta1_ibppeer.yaml
@@ -55,3 +55,4 @@ spec:
       class: ""
       size: 5G
   version: 2.2.4
+  metricsprovider: prometheus

--- a/definitions/orderer/servicemontior.yaml
+++ b/definitions/orderer/servicemontior.yaml
@@ -15,40 +15,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-apiVersion: ibp.com/v1beta1
-kind: IBPOrderer
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
 metadata:
-  name: orderera
-  namespace: example
+  name: "ibporderer-service"
 spec:
-  clusterSize: 5
-  clustersecret:
-    - enrollment: {}
-    - enrollment: {}
-    - enrollment: {}
-    - enrollment: {}
-    - enrollment: {}
-  customNames:
-    pvc: {}
-  domain: ""
-  imagePullSecrets:
-    - regcred
-  license:
-    accept: false
-  location:
-    - {}
-    - {}
-    - {}
-    - {}
-    - {}
-  mspID: ordererorg
-  ordererType: etcdraft
-  orgName: ordererorg
-  storage:
-    orderer:
-      class: ""
-      size: 5G
-  systemChannelName: testchainid
-  version: 2.2.4
-  metricsprovider: prometheus
+  selector:
+    release: "operator"
+  selector:
+    matchLabels:
+      app: "ibporderer-service"
+  endpoints:
+  - port: operations

--- a/definitions/peer/servicemontior.yaml
+++ b/definitions/peer/servicemontior.yaml
@@ -15,40 +15,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-apiVersion: ibp.com/v1beta1
-kind: IBPOrderer
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
 metadata:
-  name: orderera
-  namespace: example
+  name: "peer-service"
 spec:
-  clusterSize: 5
-  clustersecret:
-    - enrollment: {}
-    - enrollment: {}
-    - enrollment: {}
-    - enrollment: {}
-    - enrollment: {}
-  customNames:
-    pvc: {}
-  domain: ""
-  imagePullSecrets:
-    - regcred
-  license:
-    accept: false
-  location:
-    - {}
-    - {}
-    - {}
-    - {}
-    - {}
-  mspID: ordererorg
-  ordererType: etcdraft
-  orgName: ordererorg
-  storage:
-    orderer:
-      class: ""
-      size: 5G
-  systemChannelName: testchainid
-  version: 2.2.4
-  metricsprovider: prometheus
+  selector:
+    release: "operator"
+  selector:
+    matchLabels:
+      app: "peer-service"
+  endpoints:
+  - port: operations

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,3 +1,15 @@
 # Contributing to this repository
 
-## TODO
+## Tips:
+After changed module define at `/api/v1beta1/*.go` run the following command
+```
+make generate
+make manifests
+```
+to make `crd` files up to date.
+
+## Guide for operator Development
+https://sdk.operatorframework.io/docs/building-operators/golang/tutorial/
+
+## Fabric env
+for any fabric configuration as core.yaml for peer and orderer.yaml for orderer,  please considering check existing structure defined in configoverride. 

--- a/main.go
+++ b/main.go
@@ -151,6 +151,7 @@ func setDefaultPeerDefinitions(cfg *config.Config) {
 		Ingressv1beta1File:     filepath.Join(defaultPeerDef, "ingressv1beta1.yaml"),
 		CCLauncherFile:         filepath.Join(defaultPeerDef, "chaincode-launcher.yaml"),
 		RouteFile:              filepath.Join(defaultPeerDef, "route.yaml"),
+		ServiceMonitorFile:     filepath.Join(defaultPeerDef, "servicemonitor.yaml"),
 		StoragePath:            "/tmp/peerinit",
 	}
 }
@@ -173,6 +174,7 @@ func setDefaultOrdererDefinitions(cfg *config.Config) {
 		IngressFile:        filepath.Join(defaultOrdererDef, "ingress.yaml"),
 		Ingressv1beta1File: filepath.Join(defaultOrdererDef, "ingressv1beta1.yaml"),
 		RouteFile:          filepath.Join(defaultOrdererDef, "route.yaml"),
+		ServiceMonitorFile: filepath.Join(defaultPeerDef, "servicemonitor.yaml"),
 		StoragePath:        "/tmp/ordererinit",
 	}
 }

--- a/pkg/initializer/orderer/config/v1/config_test.go
+++ b/pkg/initializer/orderer/config/v1/config_test.go
@@ -19,6 +19,7 @@
 package v1_test
 
 import (
+	"github.com/IBM-Blockchain/fabric-operator/pkg/apis/common"
 	commonapi "github.com/IBM-Blockchain/fabric-operator/pkg/apis/common"
 	v1 "github.com/IBM-Blockchain/fabric-operator/pkg/apis/orderer/v1"
 	config "github.com/IBM-Blockchain/fabric-operator/pkg/initializer/orderer/config/v1"
@@ -195,6 +196,38 @@ var _ = Describe("Orderer configuration", func() {
 
 		By("setting BCCSP.PKCS11.FileKeystore.KeystorePath", func() {
 			Expect(general.BCCSP.PKCS11.FileKeyStore.KeyStorePath).To(Equal("keystore2"))
+		})
+
+	})
+
+	Context("metrics", func() {
+		It("merges current configuration with overrides values", func() {
+			orderer, err := config.ReadOrdererFile("../../../../../testdata/init/orderer/orderer.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(orderer.Metrics.Provider).To(Equal("prometheus"))
+			newWriteInterval, err := common.ParseDuration("15s")
+			Expect(err).NotTo(HaveOccurred())
+			newConfig := &config.Orderer{
+				Orderer: v1.Orderer{
+					Metrics: v1.Metrics{
+						Provider: "statsd",
+						Statsd: v1.Statsd{
+							Network:       "tcp",
+							Address:       "localhost:8080",
+							WriteInterval: newWriteInterval,
+							Prefix:        "prefix",
+						},
+					},
+				},
+			}
+			err = orderer.MergeWith(newConfig, true)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(orderer.Metrics.Provider).To(Equal("statsd"))
+			Expect(orderer.Metrics.Provider).To(Equal("statsd"))
+			Expect(orderer.Metrics.Statsd.Network).To(Equal("tcp"))
+			Expect(orderer.Metrics.Statsd.Address).To(Equal("localhost:8080"))
+			Expect(orderer.Metrics.Statsd.Prefix).To(Equal("prefix"))
+			Expect(orderer.Metrics.Statsd.WriteInterval).To(Equal(newWriteInterval))
 		})
 	})
 })

--- a/pkg/initializer/orderer/config/v24/config_test.go
+++ b/pkg/initializer/orderer/config/v24/config_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/IBM-Blockchain/fabric-operator/pkg/apis/common"
 	commonapi "github.com/IBM-Blockchain/fabric-operator/pkg/apis/common"
 	v1 "github.com/IBM-Blockchain/fabric-operator/pkg/apis/orderer/v1"
 	v24 "github.com/IBM-Blockchain/fabric-operator/pkg/apis/orderer/v24"
@@ -193,6 +194,37 @@ var _ = Describe("V2 Orderer Configuration", func() {
 
 		By("setting BCCSP.PKCS11.FileKeystore.KeystorePath", func() {
 			Expect(general.BCCSP.PKCS11.FileKeyStore.KeyStorePath).To(Equal("keystore2"))
+		})
+	})
+
+	Context("metrics", func() {
+		It("merges current configuration with overrides values", func() {
+			orderer, err := config.ReadOrdererFile("../../../../../testdata/init/orderer/orderer.yaml")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(orderer.Metrics.Provider).To(Equal("prometheus"))
+			newWriteInterval, err := common.ParseDuration("15s")
+			Expect(err).NotTo(HaveOccurred())
+			newConfig := &config.Orderer{
+				Orderer: v24.Orderer{
+					Metrics: v1.Metrics{
+						Provider: "statsd",
+						Statsd: v1.Statsd{
+							Network:       "tcp",
+							Address:       "localhost:8080",
+							WriteInterval: newWriteInterval,
+							Prefix:        "prefix",
+						},
+					},
+				},
+			}
+			err = orderer.MergeWith(newConfig, true)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(orderer.Metrics.Provider).To(Equal("statsd"))
+			Expect(orderer.Metrics.Provider).To(Equal("statsd"))
+			Expect(orderer.Metrics.Statsd.Network).To(Equal("tcp"))
+			Expect(orderer.Metrics.Statsd.Address).To(Equal("localhost:8080"))
+			Expect(orderer.Metrics.Statsd.Prefix).To(Equal("prefix"))
+			Expect(orderer.Metrics.Statsd.WriteInterval).To(Equal(newWriteInterval))
 		})
 	})
 })

--- a/pkg/initializer/orderer/initializer.go
+++ b/pkg/initializer/orderer/initializer.go
@@ -66,6 +66,7 @@ type Config struct {
 	IngressFile        string
 	Ingressv1beta1File string
 	RouteFile          string
+	ServiceMonitorFile string
 	StoragePath        string
 }
 

--- a/pkg/initializer/peer/initializer.go
+++ b/pkg/initializer/peer/initializer.go
@@ -62,6 +62,7 @@ type Config struct {
 	CCLauncherFile         string
 	RouteFile              string
 	StoragePath            string
+	ServiceMonitorFile     string
 }
 
 //go:generate counterfeiter -o mocks/ibppeer.go -fake-name IBPPeer . IBPPeer


### PR DESCRIPTION
scope for integration fabric-operator with prometheus operator.
- [x] add unit test case for prometheus metric provider in configoverride
- [ ] add test for prometheus for use prometheus and export operator ports together
- [ ] add define in peer and orderer as prometheus operator
- [ ] implementation prometheus operator for peer and orderer
- [ ] add unit test case for service monitor? do we use service?
- [ ] add CI test case with prometheus operator

additional founding
1.  doc update
2. ginkgo update in #22 


Signed-off-by: Sam Yuan <yy19902439@126.com>