### PR TITLE
Bundle a localhost:5000 container registry for local CC development

### DIFF
--- a/sample-network/network
+++ b/sample-network/network
@@ -51,6 +51,7 @@ context COREDNS_DOMAIN_OVERRIDE   true
 context LOG_FILE                  network.log
 context DEBUG_FILE                network-debug.log
 context LOG_ERROR_LINES           1
+context USE_LOCAL_REGISTRY        true
 context LOCAL_REGISTRY_NAME       kind-registry
 context LOCAL_REGISTRY_PORT       5000
 context NGINX_HTTP_PORT           80
@@ -162,7 +163,7 @@ if [ "${MODE}" == "kind" ]; then
 
 elif [ "${MODE}" == "unkind" ]; then
   log "Deleting kind cluster \"${CLUSTER_NAME}\":"
-  kind_delete
+  kind_unkind
   log "🏁 - Cluster is gone."
 
 elif [[ "${MODE}" == "cluster" || "${MODE}" == "k8s" || "${MODE}" == "kube" ]]; then

--- a/sample-network/scripts/kind.sh
+++ b/sample-network/scripts/kind.sh
@@ -107,6 +107,15 @@ EOF
   pop_fn
 }
 
+function stop_docker_registry() {
+  push_fn "Deleting container registry \"${LOCAL_REGISTRY_NAME}\" at localhost:${LOCAL_REGISTRY_PORT}"
+
+  docker kill kind-registry || true
+  docker rm kind-registry   || true
+
+  pop_fn
+}
+
 function kind_delete() {
   push_fn "Deleting KIND cluster ${CLUSTER_NAME}"
 
@@ -119,6 +128,17 @@ function kind_init() {
   set -o errexit
 
   kind_create
-  #launch_docker_registry
+
+  if [ "${USE_LOCAL_REGISTRY}" == true ]; then
+    launch_docker_registry
+  fi
 }
 
+function kind_unkind() {
+
+  kind_delete
+
+  if [ "${USE_LOCAL_REGISTRY}" == true ]; then
+    stop_docker_registry
+  fi
+}


### PR DESCRIPTION
This PR bundles an insecure docker container registry at localhost:5000.  

During local build/edit/publish cycles for chaincode and gateway application development, the local registry can be used to publish docker images to k8s without uploading images to public / Internet-based registries. 

Signed-off-by: Josh Kneubuhl <jkneubuh@us.ibm.com>