### PR TITLE
Use hyperledger-labs operator, not ibm-blockchain operator in sample network

### DIFF
--- a/sample-network/network
+++ b/sample-network/network
@@ -77,7 +77,7 @@ context ORDERER_IMAGE             ${FABRIC_CONTAINER_REGISTRY}/fabric-orderer
 context ORDERER_IMAGE_LABEL       ${FABRIC_VERSION}
 context TOOLS_IMAGE               ${FABRIC_CONTAINER_REGISTRY}/fabric-tools
 context TOOLS_IMAGE_LABEL         ${FABRIC_VERSION}
-context OPERATOR_IMAGE            ghcr.io/ibm-blockchain/fabric-operator
+context OPERATOR_IMAGE            ghcr.io/hyperledger-labs/fabric-operator
 context OPERATOR_IMAGE_LABEL      latest-amd64
 context INIT_IMAGE                registry.access.redhat.com/ubi8/ubi-minimal
 context INIT_IMAGE_LABEL          latest


### PR DESCRIPTION
After installing the operator about 50 times in test clusters, I was wondering why the image download counts from ghcr.io were still zero.  This would explain the issue... 

Sample network now pulls the LABS operator image, not the legacy rev (pre-labs).

Signed-off-by: Josh Kneubuhl <jkneubuh@us.ibm.com>