### PR TITLE
Using port 8080 for proxy probe checks to fix the errors

### DIFF
--- a/definitions/orderer/deployment.yaml
+++ b/definitions/orderer/deployment.yaml
@@ -139,7 +139,7 @@ spec:
           livenessProbe:
             failureThreshold: 6
             tcpSocket:
-              port: 7443
+              port: 8080
             initialDelaySeconds: 30
             timeoutSeconds: 5
           name: proxy
@@ -150,7 +150,7 @@ spec:
               name: https
           readinessProbe:
             tcpSocket:
-              port: 7443
+              port: 8080
             initialDelaySeconds: 26
             periodSeconds: 5
             timeoutSeconds: 5

--- a/definitions/peer/deployment.yaml
+++ b/definitions/peer/deployment.yaml
@@ -194,7 +194,7 @@ spec:
           livenessProbe:
             failureThreshold: 6
             tcpSocket:
-              port: 7443
+              port: 8080
             initialDelaySeconds: 30
             timeoutSeconds: 5
           name: proxy
@@ -205,7 +205,7 @@ spec:
               name: https
           readinessProbe:
             tcpSocket:
-              port: 7443
+              port: 8080
             initialDelaySeconds: 26
             periodSeconds: 5
             timeoutSeconds: 5


### PR DESCRIPTION
https://github.com/hyperledger-labs/fabric-operator/issues/59

Signed-off-by: asararatnakar <asara.ratnakar@gmail.com>