### PR TITLE
fix: console typo when stop sample network service

### DIFF
--- a/sample-network/scripts/test_network.sh
+++ b/sample-network/scripts/test_network.sh
@@ -166,7 +166,7 @@ function apply_network_orderers() {
 function stop_services() {
   push_fn "Stopping Fabric Services"
 
-  undo_kustomization config/consoles
+  undo_kustomization config/console
   undo_kustomization config/cas
   undo_kustomization config/peers
   undo_kustomization config/orderers


### PR DESCRIPTION
Stop service failed on `hlf console` due to typo in `sample-network/scripts/test_network.sh`