### PR TITLE
Launch the sample network on Apple Silicon;  Pin k8s to 1.24

### DIFF
--- a/sample-network/config/manager/hlf-operator-manager.yaml
+++ b/sample-network/config/manager/hlf-operator-manager.yaml
@@ -42,33 +42,27 @@ spec:
         app.kubernetes.io/name: "hlf"
         app.kubernetes.io/instance: "hlf"
         app.kubernetes.io/managed-by: "fabric-operator"
-      annotations:
-        productName: "IBM Support for Hyperledger Fabric"
-        productID: "5d5997a033594f149a534a09802d60f1"
-        productVersion: "1.0.0"
-        productChargedContainers: ""
-        productMetric: "VIRTUAL_PROCESSOR_CORE"
     spec:
       # hostIPC: false
       # hostNetwork: false
       # hostPID: false
       serviceAccountName: hlf-operator
-      affinity:
-        nodeAffinity:
-          requiredDuringSchedulingIgnoredDuringExecution:
-            nodeSelectorTerms:
-              - matchExpressions:
-                  - key: kubernetes.io/arch
-                    operator: In
-                    values:
-                      - amd64
+#      affinity:
+#        nodeAffinity:
+#          requiredDuringSchedulingIgnoredDuringExecution:
+#            nodeSelectorTerms:
+#              - matchExpressions:
+#                  - key: kubernetes.io/arch
+#                    operator: In
+#                    values:
+#                      - amd64
       # securityContext:
       #   runAsNonRoot: true
       #   runAsUser: 1001
       #   fsGroup: 2000
 
-      imagePullSecrets:
-        - name: ghcr-pull-secret
+#      imagePullSecrets:
+#        - name: image-pull-secret
 
       containers:
         - name: fabric-operator

--- a/sample-network/network
+++ b/sample-network/network
@@ -39,12 +39,13 @@ context CONTAINER_CLI             docker                # or nerdctl for contain
 context CONTAINER_NAMESPACE       ""                    # or "--namespace k8s.io" for containerd / nerdctl
 context STORAGE_CLASS             standard
 context KUSTOMIZE_BUILD           "kubectl kustomize"
-context STAGE_DOCKER_IMAGES       true
+context STAGE_DOCKER_IMAGES       false
 context FABRIC_CONTAINER_REGISTRY hyperledger
 
 context NAME                      test-network
 context NS                        $NAME
 context CLUSTER_NAME              $CLUSTER_RUNTIME
+context CLUSTER_IMAGE             kindest/node:v1.24.4  # Important! k8s v1.25.0 brings breaking changes.
 context KUBE_DNS_DOMAIN           ${NS}.svc.cluster.local
 context INGRESS_DOMAIN            localho.st
 context COREDNS_DOMAIN_OVERRIDE   true

--- a/sample-network/scripts/kind.sh
+++ b/sample-network/scripts/kind.sh
@@ -33,7 +33,7 @@ function kind_create() {
 
   # the 'ipvs'proxy mode permits better HA abilities
 
-  cat <<EOF | kind create cluster --name $CLUSTER_NAME --config=-
+  cat <<EOF | kind create cluster --name $CLUSTER_NAME --image $CLUSTER_IMAGE --config=-
 ---
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4

--- a/sample-network/scripts/test_network.sh
+++ b/sample-network/scripts/test_network.sh
@@ -87,7 +87,7 @@ function launch_network_CAs() {
   apply_kustomization config/cas
 
   # give the operator a chance to run the first reconciliation on the new resource
-  sleep 1
+  sleep 10
 
   wait_for ibpca org0-ca
   wait_for ibpca org1-ca


### PR DESCRIPTION
This PR allows the sample network to run correctly (albeit, slowly) on the new Mac Silicon / arm64 chipset.

The docker images run as `linux/amd64` under QEMU, so performance is very slow.  We should improve the build pipeline to support the `buildx` builder and generate multi-arch containers. 

This PR addresses Issue #63 by pinning the KIND target revision to 1.24.4 (`KIND_CLUSTER_IMAGE`). 

Signed-off-by: Josh Kneubuhl <jkneubuh@us.ibm.com>