### PR TITLE
Add an OPERATOR_LOCAL_MODE environment variable to launch locally.

### DIFF
--- a/docs/DEVELOPING.md
+++ b/docs/DEVELOPING.md
@@ -55,10 +55,14 @@ INT_TEST_NAME=<folder under /integration> make integration-tests
 
 ## Debug the Operator
 
-Run / debug `main.go` with env: 
-
+Launch main.go with the following environment:
 ```shell
-KUBECONFIG_PATH=$HOME/.kube/config
+export KUBECONFIG=$HOME/.kube/config
+export WATCH_NAMESPACE=test-network
+export CLUSTERTYPE=k8s
+export OPERATOR_LOCAL_MODE=true
+
+go run .
 ```
 
 

--- a/main.go
+++ b/main.go
@@ -41,11 +41,11 @@ import (
 )
 
 const (
-	defaultConfigs    = "../../defaultconfig"
-	defaultPeerDef    = "../../definitions/peer"
-	defaultCADef      = "../../definitions/ca"
-	defaultOrdererDef = "../../definitions/orderer"
-	defaultConsoleDef = "../../definitions/console"
+	defaultConfigs    = "./defaultconfig"
+	defaultPeerDef    = "./definitions/peer"
+	defaultCADef      = "./definitions/ca"
+	defaultOrdererDef = "./definitions/orderer"
+	defaultConsoleDef = "./definitions/console"
 )
 
 var log = logf.Log.WithName("cmd")
@@ -72,7 +72,7 @@ func main() {
 
 	operatorCfg.Operator.SetDefaults()
 
-	if err := command.Operator(operatorCfg, true); err != nil {
+	if err := command.Operator(operatorCfg); err != nil {
 		log.Error(err, "failed to start operator")
 		time.Sleep(15 * time.Second)
 	}

--- a/pkg/command/operator.go
+++ b/pkg/command/operator.go
@@ -71,9 +71,14 @@ func printVersion() {
 	log.Info(fmt.Sprintf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH))
 }
 
-func Operator(operatorCfg *oconfig.Config, blocking bool) error {
+func Operator(operatorCfg *oconfig.Config) error {
 	signalHandler := signals.SetupSignalHandler()
-	return OperatorWithSignal(operatorCfg, signalHandler, blocking, false)
+
+	// In local mode, the operator may be launched and debugged directly as a native process without
+	// being deployed to a Kubernetes cluster.
+	local := os.Getenv("OPERATOR_LOCAL_MODE") == "true"
+
+	return OperatorWithSignal(operatorCfg, signalHandler, true, local)
 }
 
 func OperatorWithSignal(operatorCfg *oconfig.Config, signalHandler context.Context, blocking, local bool) error {
@@ -118,7 +123,7 @@ func OperatorWithSignal(operatorCfg *oconfig.Config, signalHandler context.Conte
 			return err
 		}
 	} else {
-		log.Info("Installing operator in own namespace mode")
+		log.Info("Installing operator in own namespace mode", "WATCH_NAMESPACE", watchNamespace)
 		operatorNamespace = watchNamespace
 	}
 

--- a/pkg/command/operator.go
+++ b/pkg/command/operator.go
@@ -105,7 +105,8 @@ func OperatorWithSignal(operatorCfg *oconfig.Config, signalHandler context.Conte
 		logf.SetLogger(*operatorCfg.Logger)
 		ctrl.SetLogger(*operatorCfg.Logger)
 	} else {
-		logf.SetLogger(zap.New())
+		// Use the unstructured log formatter when running locally.
+		logf.SetLogger(zap.New(zap.UseDevMode(local)))
 		ctrl.SetLogger(zap.New(zap.UseDevMode(true)))
 	}
 


### PR DESCRIPTION
This PR allows the operator to be launched locally without running within a Docker container / kubernetes cluster.

Fixes Issue #67

Note that this changes the default path at which the operator config files are read, from `../../` to `./`.   This was actually a bug / error in the original logic, as the working directory for `ibp-operator` in the container is actually `/`.  (When running from the root folder, the `../../` path prefix resolves to `/` on the file system.)

Thank you @bjwswang for the great recommendations on pushing this forward.

Signed-off-by: Josh Kneubuhl <jkneubuh@us.ibm.com>