### PR TITLE
chore: push image workflow should limit repository

### DIFF
--- a/.github/workflows/image-build.yaml
+++ b/.github/workflows/image-build.yaml
@@ -15,6 +15,7 @@ jobs:
           scripts/install-tools.sh
           make image
       - name: Push
+        if: github.repository == 'hyperledger-labs/fabric-operator'
         run: |
           echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
           make image-push image-push-latest


### PR DESCRIPTION
The idea of automatically building the image and pushing it to the `ghcr.io` repository after the pull request merge is great. 

Just one small restriction: only run the push job on the main repository: `hyperledger-labs/fabric-operator`