### PR TITLE
fix: the clusterole name associated with clusterrolebinding is incorrect

### DIFF
--- a/config/rbac/leader_election_role.yaml
+++ b/config/rbac/leader_election_role.yaml
@@ -8,6 +8,7 @@ rules:
   - ""
   resources:
   - configmaps
+  - pods
   verbs:
   - get
   - list

--- a/config/rbac/role_binding.yaml
+++ b/config/rbac/role_binding.yaml
@@ -22,9 +22,9 @@ metadata:
   name: operator
 subjects:
   - kind: ServiceAccount
-    name: operator
-    namespace: placeholder
+    name: controller-manager
+    namespace: system
 roleRef:
   kind: ClusterRole
-  name: operator
+  name: manager-role
   apiGroup: rbac.authorization.k8s.io

--- a/config/rbac/service_account.yaml
+++ b/config/rbac/service_account.yaml
@@ -20,5 +20,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: controller-manager
+  namespace: system
 imagePullSecrets:
   - name: regcred


### PR DESCRIPTION
Signed-off-by: 0xff-dev <stevenshuang521@gmail.com>

There are some problems here.
1. ServiceAccount is missing the namespace field. kustomize cannot normally replace the namespace of serviceAccount in clusterrolebinding.
2. role_binding.yaml ClusterRoleName isn't right.