### PR TITLE
fix: occasional gosec failure to get version

### DIFF
--- a/scripts/go-sec.sh
+++ b/scripts/go-sec.sh
@@ -18,10 +18,6 @@
 # limitations under the License.
 #
 
-RELEASE=$(curl -s -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/securego/gosec/releases/latest | jq -r .tag_name)
-
-echo "Latest Gosec release determined to be $RELEASE... Installing..."
-
 curl -sfL https://raw.githubusercontent.com/securego/gosec/master/install.sh | sh -s -- -b $(go env GOPATH)/bin $RELEASE
 
 gosec ./...


### PR DESCRIPTION
gosec install script will auto get latest version(for example:https://github.com/bestchains/fabric-operator/actions/runs/3799271745/jobs/6461638960#step:5:7).  Not only is it unnecessary to get latest version, but this request is easily rejected by github, resulting in a `null` version (for example https://github.com/bestchains/fabric-operator/actions/runs/3799115622/jobs/6461341294#step:5:7) and installation failure.

Signed-off-by: Abirdcfly <fp544037857@gmail.com>