### PR TITLE
Add support for CA Idemix config override stanza

### DIFF
--- a/pkg/apis/ca/v1/ca.go
+++ b/pkg/apis/ca/v1/ca.go
@@ -88,6 +88,7 @@ type CAConfig struct {
 	CSP          *BCCSP                 `json:"bccsp,omitempty"`
 	Intermediate IntermediateCA         `json:"intermediate,omitempty"`
 	CRL          CRLConfig              `json:"crl,omitempty"`
+	Idemix       IdemixConfig           `json:"idemix,omitempty"`
 
 	// Optional client config for an intermediate server which acts as a client
 	// of the root (or parent) server
@@ -341,6 +342,18 @@ type CRLConfig struct {
 	// The number of hours specified by this property is added to the UTC time, resulting time
 	// is used to set the 'Next Update' date of the CRL
 	Expiry commonapi.Duration `json:"expiry,omitempty"`
+}
+
+// IdemixConfig encapsulates Idemix related the configuration options
+type IdemixConfig struct {
+	Curve                    string `json:"curve,omitempty"`
+	IssuerPublicKeyfile      string `json:"issuerpublickeyfile,omitempty"`
+	IssuerSecretKeyfile      string `json:"issuersecretkeyfile,omitempty"`
+	RevocationPublicKeyfile  string `json:"revocationpublickeyfile,omitempty"`
+	RevocationPrivateKeyfile string `json:"revocationprivatekeyfile,omitempty"`
+	RHPoolSize               int    `json:"rhpoolsize,omitempty"`
+	NonceExpiration          string `json:"nonceexpiration,omitempty"`
+	NonceSweepInterval       string `json:"noncesweepinterval,omitempty"`
 }
 
 // Options contains configuration for the operations system

--- a/release_notes/v1.0.4-2.md
+++ b/release_notes/v1.0.4-2.md
@@ -1,0 +1,25 @@
+v1.0.4-2 Release notes - Jan 5, 2023
+------------------------
+
+Release Notes
+-------------
+
+v1.0.4-2 is a patch release, providing updates for the following issues in the operator: 
+
+- Adds support for [Idemix config](https://github.com/hyperledger/fabric-ca/blob/main/lib/server/idemix/config.go#L29) overrides in CA CRD spec.configoverride
+
+Known Vulnerabilities
+---------------------
+none
+
+Resolved Vulnerabilities
+------------------------
+none
+
+Known Issues & Workarounds
+--------------------------
+none
+
+Change Log
+----------
+none


### PR DESCRIPTION
Adds support for Idemix configuration parameters to the CA CRD `spec.configoverride.ca.idemix` stanza.

Signed-off-by: Josh Kneubuhl <jkneubuh@us.ibm.com>