### PR TITLE
fix: when not using couchdb, the resources of peer's init container d…

### DIFF
--- a/pkg/offering/base/peer/override/deployment.go
+++ b/pkg/offering/base/peer/override/deployment.go
@@ -709,6 +709,13 @@ func (o *Override) CommonDeploymentOverrides(instance *current.IBPPeer, deployme
 			}
 		}
 
+		if resourcesRequest.Init != nil {
+			err = initContainer.UpdateResources(resourcesRequest.Init)
+			if err != nil {
+				return errors.Wrap(err, "resource update for init failed")
+			}
+		}
+
 		if instance.UsingCouchDB() {
 			couchdb := deployment.MustGetContainer(COUCHDB)
 			if resourcesRequest.CouchDB != nil {


### PR DESCRIPTION
…oes not take effect