### PR TITLE
fix: E2E testing failed but displayed success

### DIFF
--- a/.github/workflows/endtoend-tests.yaml
+++ b/.github/workflows/endtoend-tests.yaml
@@ -31,4 +31,8 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Sample Network E2E Test
-        run: sample-network/scripts/run-e2e-test.sh || cat sample-network/network-debug.log
+        run: sample-network/scripts/run-e2e-test.sh
+
+      - name: Show Debug Log
+        if: ${{ always() }}
+        run: cat sample-network/network-debug.log


### PR DESCRIPTION
Close #102 
Close #104

#102 Shows a situation where the test failed but showed success.(This is not correct.)
#104 Shows that merge the current commit, the test fails and the display also fails.(This is correct.)