### PR TITLE
Include legacy dns in the tlscerts to fix post migration issues

### DIFF
--- a/pkg/offering/base/ca/ca.go
+++ b/pkg/offering/base/ca/ca.go
@@ -808,6 +808,7 @@ func (ca *CA) GenTLSCrypto(instance *current.IBPCA, endpoints *current.CAEndpoin
 	ip := net.ParseIP(endpoints.API)
 	if ip == nil {
 		template.DNSNames = append(template.DNSNames, endpoints.API)
+		template.DNSNames = append(template.DNSNames, strings.Replace(endpoints.API, "-ca.", ".", -1))
 	} else {
 		template.IPAddresses = append(template.IPAddresses, ip)
 	}

--- a/pkg/offering/k8s/orderer/orderer.go
+++ b/pkg/offering/k8s/orderer/orderer.go
@@ -131,14 +131,15 @@ func (o *Orderer) ReconcileNode(instance *current.IBPOrderer, update baseorderer
 	hostAPI := fmt.Sprintf("%s-%s-orderer.%s", instance.Namespace, instance.Name, instance.Spec.Domain)
 	hostOperations := fmt.Sprintf("%s-%s-operations.%s", instance.Namespace, instance.Name, instance.Spec.Domain)
 	hostGrpc := fmt.Sprintf("%s-%s-grpcweb.%s", instance.Namespace, instance.Name, instance.Spec.Domain)
+	legacyHostAPI := fmt.Sprintf("%s-%s.%s", instance.Namespace, instance.Name, instance.Spec.Domain)
 	hosts := []string{}
 	currentVer := version.String(instance.Spec.FabricVersion)
 	if currentVer.EqualWithoutTag(version.V2_4_1) || currentVer.EqualWithoutTag(version.V2_5_1) || currentVer.GreaterThan(version.V2_4_1) {
 		hostAdmin := fmt.Sprintf("%s-%s-admin.%s", instance.Namespace, instance.Name, instance.Spec.Domain)
-		hosts = append(hosts, hostAPI, hostOperations, hostGrpc, hostAdmin, "127.0.0.1")
+		hosts = append(hosts, hostAPI, hostOperations, hostGrpc, hostAdmin, legacyHostAPI, "127.0.0.1")
 		//TODO: need to Re-enroll when orderer migrated from 1.4.x/2.2.x to 2.4.1
 	} else {
-		hosts = append(hosts, hostAPI, hostOperations, hostGrpc, "127.0.0.1")
+		hosts = append(hosts, hostAPI, hostOperations, hostGrpc, legacyHostAPI, "127.0.0.1")
 	}
 
 	o.CheckCSRHosts(instance, hosts)

--- a/pkg/offering/k8s/peer/peer.go
+++ b/pkg/offering/k8s/peer/peer.go
@@ -133,7 +133,8 @@ func (p *Peer) Reconcile(instance *current.IBPPeer, update basepeer.Update) (com
 	hostAPI := fmt.Sprintf("%s-%s-peer.%s", instance.Namespace, instance.Name, instance.Spec.Domain)
 	hostOperations := fmt.Sprintf("%s-%s-operations.%s", instance.Namespace, instance.Name, instance.Spec.Domain)
 	hostGrpcWeb := fmt.Sprintf("%s-%s-grpcweb.%s", instance.Namespace, instance.Name, instance.Spec.Domain)
-	hosts := []string{hostAPI, hostOperations, hostGrpcWeb, "127.0.0.1"}
+	legacyHostAPI := fmt.Sprintf("%s-%s.%s", instance.Namespace, instance.Name, instance.Spec.Domain)
+	hosts := []string{hostAPI, hostOperations, hostGrpcWeb, legacyHostAPI, "127.0.0.1"}
 	csrHostUpdated := p.CheckCSRHosts(instance, hosts)
 
 	if instanceUpdated || externalEndpointUpdated || csrHostUpdated {

--- a/pkg/offering/openshift/orderer/orderer.go
+++ b/pkg/offering/openshift/orderer/orderer.go
@@ -128,13 +128,14 @@ func (o *Orderer) ReconcileNode(instance *current.IBPOrderer, update baseorderer
 	hostAPI := fmt.Sprintf("%s-%s-orderer.%s", instance.Namespace, instance.Name, instance.Spec.Domain)
 	hostOperations := fmt.Sprintf("%s-%s-operations.%s", instance.Namespace, instance.Name, instance.Spec.Domain)
 	hostGrpc := fmt.Sprintf("%s-%s-grpcweb.%s", instance.Namespace, instance.Name, instance.Spec.Domain)
+	legacyHostAPI := fmt.Sprintf("%s-%s.%s", instance.Namespace, instance.Name, instance.Spec.Domain)
 	hosts := []string{}
 	currentVer := version.String(instance.Spec.FabricVersion)
 	if currentVer.EqualWithoutTag(version.V2_4_1) || currentVer.EqualWithoutTag(version.V2_5_1) || currentVer.GreaterThan(version.V2_4_1) {
 		hostAdmin := fmt.Sprintf("%s-%s-admin.%s", instance.Namespace, instance.Name, instance.Spec.Domain)
-		hosts = append(hosts, hostAPI, hostOperations, hostGrpc, hostAdmin, "127.0.0.1")
+		hosts = append(hosts, hostAPI, hostOperations, hostGrpc, hostAdmin, legacyHostAPI, "127.0.0.1")
 	} else {
-		hosts = append(hosts, hostAPI, hostOperations, hostGrpc, "127.0.0.1")
+		hosts = append(hosts, hostAPI, hostOperations, hostGrpc, legacyHostAPI, "127.0.0.1")
 	}
 
 	o.CheckCSRHosts(instance, hosts)

--- a/pkg/offering/openshift/peer/peer.go
+++ b/pkg/offering/openshift/peer/peer.go
@@ -154,7 +154,8 @@ func (p *Peer) Reconcile(instance *current.IBPPeer, update basepeer.Update) (com
 	hostAPI := fmt.Sprintf("%s-%s-peer.%s", instance.Namespace, instance.Name, instance.Spec.Domain)
 	hostOperations := fmt.Sprintf("%s-%s-operations.%s", instance.Namespace, instance.Name, instance.Spec.Domain)
 	hostGrpc := fmt.Sprintf("%s-%s-grpcweb.%s", instance.Namespace, instance.Name, instance.Spec.Domain)
-	hosts := []string{hostAPI, hostOperations, hostGrpc, "127.0.0.1"}
+	legacyHostAPI := fmt.Sprintf("%s-%s.%s", instance.Namespace, instance.Name, instance.Spec.Domain)
+	hosts := []string{hostAPI, hostOperations, hostGrpc, legacyHostAPI, "127.0.0.1"}
 	csrHostUpdated := p.CheckCSRHosts(instance, hosts)
 
 	if instanceUpdated || externalEndpointUpdated || csrHostUpdated {


### PR DESCRIPTION
https://github.com/hyperledger-labs/fabric-operator/issues/118