### PR TITLE
console role definition replicasets resources typo correction

### DIFF
--- a/definitions/console/role.yaml
+++ b/definitions/console/role.yaml
@@ -62,7 +62,7 @@ rules:
       - pods/log
       - persistentvolumeclaims
       - deployments
-      - replicas
+      - replicasets
       - ingresses
     verbs:
       - "get"


### PR DESCRIPTION
https://github.com/hyperledger-labs/fabric-operator/issues/177
In RBAC role definition for a console for app group, we have added resources as `- replicas` instead of `- replicasets`. Due to this replicasets are not accessible for the user with that RBAC.