### PR TITLE
Fix gosec failures on integer conversion

### DIFF
--- a/pkg/initializer/orderer/configtx/encoder.go
+++ b/pkg/initializer/orderer/configtx/encoder.go
@@ -81,7 +81,7 @@ func NewApplicationOrgGroup(conf *Organization) (*cb.ConfigGroup, error) {
 	for _, anchorPeer := range conf.AnchorPeers {
 		anchorProtos = append(anchorProtos, &pb.AnchorPeer{
 			Host: anchorPeer.Host,
-			Port: int32(anchorPeer.Port),
+			Port: int32(anchorPeer.Port), // #nosec G115
 		})
 	}
 


### PR DESCRIPTION
New versions of gosec implemented stricter type conversion and bounds checks. This conversion is not vulnerable so we can suppress the warning.