### PR TITLE
Fix 'occured' -> 'occurred' in controller tests (4 files)

### DIFF
--- a/controllers/ibpca/ibpca_controller_test.go
+++ b/controllers/ibpca/ibpca_controller_test.go
@@ -271,7 +271,7 @@ var _ = Describe("ReconcileIBPCA", func() {
 	})
 
 	Context("set status", func() {
-		It("sets the status to error if error occured during IBPCA reconciliation", func() {
+		It("sets the status to error if error occurred during IBPCA reconciliation", func() {
 			reconciler.SetStatus(instance, nil, errors.New("ibpca error"))
 			Expect(instance.Status.Type).To(Equal(current.Error))
 			Expect(instance.Status.Message).To(Equal("ibpca error"))

--- a/controllers/ibpconsole/ibpconsole_controller_test.go
+++ b/controllers/ibpconsole/ibpconsole_controller_test.go
@@ -180,7 +180,7 @@ var _ = Describe("ReconcileIBPConsole", func() {
 			Expect(err).To(HaveOccurred())
 		})
 
-		It("sets the status to error if error occured during IBPConsole reconciliation", func() {
+		It("sets the status to error if error occurred during IBPConsole reconciliation", func() {
 			reconciler.SetStatus(instance, errors.New("ibpconsole error"))
 			Expect(instance.Status.Type).To(Equal(current.Error))
 			Expect(instance.Status.Message).To(Equal("ibpconsole error"))

--- a/controllers/ibporderer/ibporderer_controller_test.go
+++ b/controllers/ibporderer/ibporderer_controller_test.go
@@ -176,7 +176,7 @@ var _ = Describe("ReconcileIBPOrderer", func() {
 		})
 
 		Context("set status", func() {
-			It("sets the status to error if error occured during IBPOrderer reconciliation", func() {
+			It("sets the status to error if error occurred during IBPOrderer reconciliation", func() {
 				reconciler.SetStatus(instance, nil, errors.New("ibporderer error"))
 				Expect(instance.Status.Type).To(Equal(current.Error))
 				Expect(instance.Status.Message).To(Equal("ibporderer error"))

--- a/controllers/ibppeer/ibppeer_controller_test.go
+++ b/controllers/ibppeer/ibppeer_controller_test.go
@@ -628,7 +628,7 @@ var _ = Describe("ReconcileIBPPeer", func() {
 	})
 
 	Context("set status", func() {
-		It("sets the status to error if error occured during IPBPPeer reconciliation", func() {
+		It("sets the status to error if error occurred during IPBPPeer reconciliation", func() {
 			reconciler.SetStatus(instance, nil, errors.New("ibppeer error"))
 			Expect(instance.Status.Type).To(Equal(current.Error))
 			Expect(instance.Status.Message).To(Equal("ibppeer error"))


### PR DESCRIPTION
Test-only typo fix in 4 ibp*_controller_test.go files. Test assertion comments only.